### PR TITLE
Update Redis containers and make it slower but more resilient to outages

### DIFF
--- a/redis/configmap.yaml
+++ b/redis/configmap.yaml
@@ -13,6 +13,8 @@ data:
     # User-supplied common configuration:
     # Enable AOF https://redis.io/topics/persistence#append-only-file
     appendonly yes
+    # https://github.com/Five-Borough-Fedi-Project/masto.nyc/issues/1
+    appendfsync always
     # Disable RDB persistence, AOF persistence already enabled.
     save ""
     # End of common configuration

--- a/redis/master/application.yaml
+++ b/redis/master/application.yaml
@@ -31,8 +31,15 @@ spec:
         fsGroup: 1001
       serviceAccountName: mastodon-redis
       affinity:
-        podAffinity:
-          
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                # dirty hardcoding of hostnames.
+                values:
+                - microwave
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:
@@ -50,7 +57,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: redis
-          image: docker.io/bitnami/redis:6.2.7-debian-11-r11
+          image: docker.io/bitnami/redis:7.2.4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsUser: 1001

--- a/redis/replicas/statefulset.yaml
+++ b/redis/replicas/statefulset.yaml
@@ -27,13 +27,19 @@ spec:
         app.kubernetes.io/instance: mastodon
         app.kubernetes.io/component: replica
     spec:
-      
       securityContext:
         fsGroup: 1001
       serviceAccountName: mastodon-redis
       affinity:
-        podAffinity:
-          
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                # dirty hardcoding of hostnames.
+                values:
+                - microwave
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:
@@ -46,12 +52,10 @@ spec:
                   - "mastodon"
                 topologyKey: kubernetes.io/hostname
               weight: 1
-        nodeAffinity:
-          
       terminationGracePeriodSeconds: 30
       containers:
         - name: redis
-          image: docker.io/bitnami/redis:6.2.7-debian-11-r11
+          image: docker.io/bitnami/redis:7.2.4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsUser: 1001


### PR DESCRIPTION
#1 Outlines the driver for these changes. This:

1. upgrades the container images from `redis:6.2.7-debian-11-r11` to `redis:7.2.4`
2. forces the replica to not be on the same node as the primary >_<
3. forces `appendfsync always`. This makes Redis much more slow, allegedly. But it should make it more resilient to outages. Manually babying this thing back to life is not a scalable nor sustainable solution. 

I'll periodically monitor the performance to make sure things aren't awful.